### PR TITLE
Lane Swapping Character Controller

### DIFF
--- a/Assets/Scenes/carMain.unity
+++ b/Assets/Scenes/carMain.unity
@@ -647,6 +647,7 @@ GameObject:
   m_Component:
   - component: {fileID: 1869740667}
   - component: {fileID: 1869740666}
+  - component: {fileID: 1869740668}
   m_Layer: 0
   m_Name: Player
   m_TagString: Player
@@ -662,7 +663,7 @@ SphereCollider:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1869740665}
   m_Material: {fileID: 0}
-  m_IsTrigger: 0
+  m_IsTrigger: 1
   m_Enabled: 1
   serializedVersion: 2
   m_Radius: 0.06
@@ -675,7 +676,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1869740665}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 1.75, z: 0}
+  m_LocalPosition: {x: 1.05, y: 1.75, z: 0}
   m_LocalScale: {x: 10, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
@@ -683,6 +684,25 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 4
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &1869740668
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1869740665}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: df38ff61b61701b4c8ec35784c28db19, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  Lanes:
+  - {fileID: 1971551053}
+  - {fileID: 1923581806}
+  - {fileID: 945191928}
+  startingLane: 1
+  currentLane: 0
+  smoothTime: 0.1
 --- !u!1 &1923581806
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/PlayerCarController.cs
+++ b/Assets/Scripts/PlayerCarController.cs
@@ -1,0 +1,38 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class PlayerCarController : MonoBehaviour
+{
+    // Start is called before the first frame update
+    public GameObject[] Lanes;
+    public int startingLane = 1;
+    [SerializeField]
+    private int currentLane;
+
+    //Things Needed For Smooth Damp
+    public float smoothTime = 0.3F;
+    private Vector3 velocity = Vector3.zero;
+
+    void Start() {
+        currentLane = startingLane;
+        transform.position = Lanes[startingLane].GetComponent<Transform>().position;
+    }
+
+    void Update() {
+        InputHandler();
+        LerpPosition();
+    }
+
+    void InputHandler() {
+        if(Input.GetAxisRaw("Horizontal") > 0.1f && Input.GetButtonDown("Horizontal")) currentLane++;
+        if(Input.GetAxisRaw("Horizontal") < -0.1f && Input.GetButtonDown("Horizontal")) currentLane--;
+        currentLane = Mathf.Clamp(currentLane, 0, Lanes.GetLength(0) - 1);
+    }
+
+    void LerpPosition()
+    {
+            // Use Mathf.Lerp to interpolate between the start and end positions
+        transform.position = Vector3.SmoothDamp(transform.position, Lanes[currentLane].GetComponent<Transform>().position, ref velocity, smoothTime);
+    }
+}

--- a/Assets/Scripts/PlayerCarController.cs.meta
+++ b/Assets/Scripts/PlayerCarController.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: df38ff61b61701b4c8ec35784c28db19
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Character now can move between set positions of game objects. These objects can be translated, moved, and had their size changed. Code right now supports tedious adding all points in hierarchy editor because I felt like that would be enough for now. If need the need arises however I can write the code to dynamically cycle through the children of an object alphabetically in order to get the path order.